### PR TITLE
Process lobe geometry on GPU

### DIFF
--- a/Scripts/gl-wrangling-funcs.js
+++ b/Scripts/gl-wrangling-funcs.js
@@ -47,9 +47,19 @@ var setup_program = function(vsSource, fsSource){
   return program;
 };
 
+var get_initial_V = function(){
+  var cam_z = 1.5; // z-position of camera in camera space
+  var cam_y = 0.5; // altitude of camera
+  var V = [1,      0,     0, 0,
+           0,      0,     1, 0,
+           0,      1,     0, 0,
+           0, -cam_y,-cam_z, 1];
+  return V;
+};
+
 //TODO: We may want to pre-allocate V and pass it in if we end up changing V
 //often.
-var setupMVP = function(program, mUniformLoc, vUniformLoc, pUniformLoc){
+var setupMVP = function(program, mUniformLoc, vUniformLoc, pUniformLoc, initial_V){
   
   /*
    * gl-matrix stores matrices in column-major order
@@ -68,23 +78,22 @@ var setupMVP = function(program, mUniformLoc, vUniformLoc, pUniformLoc){
    * 0 0 0 0
    */
 
-  var cam_z = 1.5; // z-position of camera in camera space
-  var cam_y = 0.5; // altitude of camera
 
   // BRDF is in tangent space. Tangent space is Z-up.
   // Also, we need to move the camera so that it's not at the origin 
-  var V = [1,      0,     0, 0,
-           0,      0,     1, 0,
-           0,      1,     0, 0,
-           0, -cam_y,-cam_z, 1];
   
   //var V = [1,      0,     0, 0,
            //0,      1,     0, 0,
            //0,      0,     1, 0,
            //0,      0,-cam_z, 1];
 
+  var V = initial_V; 
+
+  var M = mat4.create(); //creates identity
+
   gl.useProgram(program);
   gl.uniformMatrix4fv(vUniformLoc, false, V);
+  gl.uniformMatrix4fv(mUniformLoc, false, M);
 
   // Perspective projection
   var fov = Math.PI * 0.5;
@@ -100,9 +109,10 @@ var setupMVP = function(program, mUniformLoc, vUniformLoc, pUniformLoc){
 };
 
 //prev_time is the time when previous frame was drawn
-function updateMVP(M,program,mUniformLoc){
+//Right now we only need to update V.
+function updateMVP(V,program,vUniformLoc){
   gl.useProgram(program);
-  gl.uniformMatrix4fv(mUniformLoc, false, M);
+  gl.uniformMatrix4fv(vUniformLoc, false, V);
 };
 
 //output is unit reflected vector

--- a/Scripts/gl-wrangling-funcs.js
+++ b/Scripts/gl-wrangling-funcs.js
@@ -77,6 +77,11 @@ var setupMVP = function(program, mUniformLoc, vUniformLoc, pUniformLoc){
            0,      0,     1, 0,
            0,      1,     0, 0,
            0, -cam_y,-cam_z, 1];
+  
+  //var V = [1,      0,     0, 0,
+           //0,      1,     0, 0,
+           //0,      0,     1, 0,
+           //0,      0,-cam_z, 1];
 
   gl.useProgram(program);
   gl.uniformMatrix4fv(vUniformLoc, false, V);
@@ -197,6 +202,7 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
   var pos_dim = 3;
   var color_dim = 3;
   var norm_dim = 3;
+  var polar_dim = 2;
 
   var positions = [];
   var colors = [];
@@ -222,6 +228,8 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
 
   //var indices = [];
   var normals = [];
+  var polar_coords = [];
+
 
   var polar_to_cartesian = function(theta_deg,phi_deg){
       // radians
@@ -271,10 +279,12 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
       //Right now these four points are on a perfect hemisphere... 
 
       //Scale by BRDF
-      p = shade_vtx(L_hat,N_hat,p);
-      p_k_plus_1 = shade_vtx(L_hat,N_hat,p_k_plus_1);
-      p_k_plus_N = shade_vtx(L_hat,N_hat,p_k_plus_N);
-      p_k_plus_N_plus_1 = shade_vtx(L_hat,N_hat,p_k_plus_N_plus_1);
+      /*
+       *p = shade_vtx(L_hat,N_hat,p);
+       *p_k_plus_1 = shade_vtx(L_hat,N_hat,p_k_plus_1);
+       *p_k_plus_N = shade_vtx(L_hat,N_hat,p_k_plus_N);
+       *p_k_plus_N_plus_1 = shade_vtx(L_hat,N_hat,p_k_plus_N_plus_1);
+       */
 
       //Four color attributes of our quad 
       var c = polar_to_color(theta_deg,phi_deg); 
@@ -301,6 +311,9 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
       colors.push(c_k_plus_1[0],c_k_plus_1[1],c_k_plus_1[2]); 
       colors.push(c_k_plus_N_plus_1[0],c_k_plus_N_plus_1[1],c_k_plus_N_plus_1[2]); 
       normals.push(n[0],n[1],n[2]); normals.push(n[0],n[1],n[2]); normals.push(n[0],n[1],n[2]);
+      polar_coords.push(theta_deg,phi_deg);
+      polar_coords.push(theta_deg, (j+1)*delPhi);
+      polar_coords.push((i+1)*delTheta, (j+1)*delPhi);
 
       //p_k --> p_k_plus_N_plus_1 --> p_k_plus_N  
       positions.push(p[0],p[1],p[2]); 
@@ -310,6 +323,9 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
       colors.push(c_k_plus_N_plus_1[0],c_k_plus_N_plus_1[1],c_k_plus_N_plus_1[2]); 
       colors.push(c_k_plus_N[0],c_k_plus_N[1],c_k_plus_N[2]); 
       normals.push(n[0],n[1],n[2]); normals.push(n[0],n[1],n[2]); normals.push(n[0],n[1],n[2]);
+      polar_coords.push(theta_deg,phi_deg);
+      polar_coords.push((i+1)*delTheta, (j+1)*delPhi);
+      polar_coords.push((i+1)*delTheta, phi_deg);
       num_verts += 6;
         //num_verts += 3;
 
@@ -381,5 +397,13 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(normals), gl.DYNAMIC_DRAW);
   gl.vertexAttribPointer(normalAttribLoc, norm_dim, gl.FLOAT, false, 0, 0);
   gl.enableVertexAttribArray(normalAttribLoc); 
+
+  const polar_coordAttribLoc = 3;
+  const polar_coordBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, polar_coordBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(polar_coords), gl.DYNAMIC_DRAW);
+  gl.vertexAttribPointer(polar_coordAttribLoc, polar_dim, gl.FLOAT, false, 0, 0);
+  gl.enableVertexAttribArray(polar_coordAttribLoc); 
+
   return num_verts;
 };

--- a/Scripts/gl-wrangling-funcs.js
+++ b/Scripts/gl-wrangling-funcs.js
@@ -189,14 +189,22 @@ var line_setupGeometry = function(lineVAO, L_hat, N_hat){
   return num_verts;
 };
 
+var calc_delTheta = function(numThetaDivisions){
+  return 90 / numThetaDivisions;
+};
+
+var calc_delPhi = function(numPhiDivisions){
+  return 360 / numPhiDivisions;
+};
+
 //ASSSUMES THAT POSITIONS ARE AT ATTRIBUTE 0, COLORS AT ATTRIBUTE 1,
 //NORMALS AT ATTRIBUTE 2 IN SHADER.
-var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
+var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat, numPhiDivisions, numThetaDivisions){
   
   gl.bindVertexArray(lobeVAO);
 
-  var numPhiDivisions = 200;
-  var numThetaDivisions = 100;
+  //var numPhiDivisions = 200;
+  //var numThetaDivisions = 100;
 
   //Dimensionality of positions, colors, normals
   var pos_dim = 3;
@@ -207,8 +215,11 @@ var lobe_setupGeometry = function(lobeVAO, L_hat, N_hat){
   var positions = [];
   var colors = [];
 
-  var delTheta = 90 / numThetaDivisions;
-  var delPhi = 360 / numPhiDivisions;
+  //var delTheta = 90 / numThetaDivisions;
+  //var delPhi = 360 / numPhiDivisions;
+  
+  var delTheta = calc_delTheta(numThetaDivisions); 
+  var delPhi = calc_delPhi(numPhiDivisions);
 
   var diffuse = function(light_dir, normal_dir){
     return Math.max(0,vec3.dot(light_dir, normal_dir));

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -35,6 +35,9 @@ const lobe_mUniformLoc = gl.getUniformLocation(lobeProgram, "u_m"); // model mat
 const lobe_vUniformLoc = gl.getUniformLocation(lobeProgram, "u_v"); // view matrix
 const lobe_pUniformLoc = gl.getUniformLocation(lobeProgram, "u_p"); // proj matrix
 
+const lobe_delThetaUniformLoc = gl.getUniformLocation(lobeProgram, "u_delTheta"); 
+const lobe_delPhiUniformLoc = gl.getUniformLocation(lobeProgram, "u_delPhi"); 
+
 const line_mUniformLoc = gl.getUniformLocation(lineProgram, "u_m"); 
 const line_vUniformLoc = gl.getUniformLocation(lineProgram, "u_v"); 
 const line_pUniformLoc = gl.getUniformLocation(lineProgram, "u_p"); 
@@ -65,6 +68,8 @@ var lobeVAO = gl.createVertexArray();
 var numPhiDivisions = 200;
 var numThetaDivisions = 100;
 var num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numPhiDivisions, numThetaDivisions);
+gl.uniform1f(lobe_delPhiUniformLoc,calc_delPhi(numPhiDivisions));
+gl.uniform1f(lobe_delThetaUniformLoc,calc_delTheta(numThetaDivisions));
 
 var lineVAO = gl.createVertexArray();
 //Assumes positions at attribute 0, colors at attribute 1 in line shader

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -98,7 +98,7 @@ document.getElementById("slider_incidentTheta").oninput = function(event) {
   in_theta_deg = event.target.value;
   output_incidentTheta.innerHTML = in_theta_deg;
   L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
-  num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat);
+  num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numThetaDivisions, numPhiDivisions);
   num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);
 };
 
@@ -106,7 +106,7 @@ document.getElementById("slider_incidentPhi").oninput = function(event) {
   in_phi_deg = event.target.value;
   output_incidentPhi.innerHTML = in_phi_deg;
   L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
-  num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat);
+  num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numThetaDivisions, numPhiDivisions);
   num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);
 };
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -61,7 +61,10 @@ var N_hat = compute_N_hat();
 var lobeVAO = gl.createVertexArray();
 //Assumes positions at attribute 0, colors at attribute 1, 
 //normals at attribute 2 in lobe shader
-var num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat);
+
+var numPhiDivisions = 200;
+var numThetaDivisions = 100;
+var num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numPhiDivisions, numThetaDivisions);
 
 var lineVAO = gl.createVertexArray();
 //Assumes positions at attribute 0, colors at attribute 1 in line shader

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -120,6 +120,8 @@ document.getElementById("slider_incidentPhi").oninput = function(event) {
   in_phi_deg = event.target.value;
   output_incidentPhi.innerHTML = in_phi_deg;
   L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
+  gl.useProgram(lobeProgram);
+  gl.uniform3fv(lobe_lUniformLoc,L_hat);
   //console.log(L_hat);
   num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numThetaDivisions, numPhiDivisions);
   num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -23,7 +23,7 @@ gl.enable(gl.DEPTH_TEST);
 // SET UP PROGRAM
 /////////////////////
 
-const lobeVsSource = document.getElementById("phong.vert").text.trim();
+const lobeVsSource = document.getElementById("lobe.vert").text.trim();
 const lobeFsSource = document.getElementById("phong.frag").text.trim();
 const lineVsSource = document.getElementById("color_only.vert").text.trim();
 const lineFsSource = document.getElementById("color_only.frag").text.trim();

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -35,6 +35,9 @@ const lobe_mUniformLoc = gl.getUniformLocation(lobeProgram, "u_m"); // model mat
 const lobe_vUniformLoc = gl.getUniformLocation(lobeProgram, "u_v"); // view matrix
 const lobe_pUniformLoc = gl.getUniformLocation(lobeProgram, "u_p"); // proj matrix
 
+const lobe_nUniformLoc = gl.getUniformLocation(lobeProgram, "u_n"); // unit normal 
+const lobe_lUniformLoc = gl.getUniformLocation(lobeProgram, "u_l"); // unit in-direction
+
 const lobe_delThetaUniformLoc = gl.getUniformLocation(lobeProgram, "u_delTheta"); 
 const lobe_delPhiUniformLoc = gl.getUniformLocation(lobeProgram, "u_delPhi"); 
 
@@ -58,8 +61,6 @@ const line_pUniformLoc = gl.getUniformLocation(lineProgram, "u_p");
 var in_theta_deg = 45;
 var in_phi_deg = 0;
 
-var L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
-var N_hat = compute_N_hat();
 
 var lobeVAO = gl.createVertexArray();
 //Assumes positions at attribute 0, colors at attribute 1, 
@@ -67,7 +68,12 @@ var lobeVAO = gl.createVertexArray();
 
 var numPhiDivisions = 200;
 var numThetaDivisions = 100;
+var L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
+var N_hat = compute_N_hat();
 var num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numPhiDivisions, numThetaDivisions);
+gl.useProgram(lobeProgram);
+gl.uniform3fv(lobe_nUniformLoc,N_hat);
+gl.uniform3fv(lobe_lUniformLoc,L_hat);
 gl.uniform1f(lobe_delPhiUniformLoc,calc_delPhi(numPhiDivisions));
 gl.uniform1f(lobe_delThetaUniformLoc,calc_delTheta(numThetaDivisions));
 
@@ -103,6 +109,9 @@ document.getElementById("slider_incidentTheta").oninput = function(event) {
   in_theta_deg = event.target.value;
   output_incidentTheta.innerHTML = in_theta_deg;
   L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
+  gl.useProgram(lobeProgram);
+  gl.uniform3fv(lobe_lUniformLoc,L_hat);
+  //console.log(L_hat);
   num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numThetaDivisions, numPhiDivisions);
   num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);
 };
@@ -111,6 +120,7 @@ document.getElementById("slider_incidentPhi").oninput = function(event) {
   in_phi_deg = event.target.value;
   output_incidentPhi.innerHTML = in_phi_deg;
   L_hat = compute_L_hat(in_theta_deg, in_phi_deg);
+  //console.log(L_hat);
   num_lobe_verts = lobe_setupGeometry(lobeVAO, L_hat, N_hat, numThetaDivisions, numPhiDivisions);
   num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);
 };

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -81,8 +81,10 @@ var lineVAO = gl.createVertexArray();
 //Assumes positions at attribute 0, colors at attribute 1 in line shader
 var num_line_verts = line_setupGeometry(lineVAO, L_hat, N_hat);
 
-setupMVP(lobeProgram, lobe_mUniformLoc, lobe_vUniformLoc, lobe_pUniformLoc);
-setupMVP(lineProgram, line_mUniformLoc, line_vUniformLoc, line_pUniformLoc);
+var V = get_initial_V(); 
+
+setupMVP(lobeProgram, lobe_mUniformLoc, lobe_vUniformLoc, lobe_pUniformLoc, V);
+setupMVP(lineProgram, line_mUniformLoc, line_vUniformLoc, line_pUniformLoc, V);
 
 var prev_time = 0; //time when the previous frame was drawn
 var rot = 0;
@@ -91,7 +93,7 @@ var rot_angle = 0; // radians
 var rot_axis = vec3.create();
 vec3.set(rot_axis, 0, 0, 1);
 
-var M = mat4.create();
+//var M = mat4.create();
 
 /////////////////////
 // SET UP UI CALLBACKS 
@@ -131,7 +133,13 @@ var output_camRot = document.getElementById("output_camRot");
 document.getElementById("slider_camRot").oninput = function(event) {
   var rot_angle_deg = event.target.value;
   rot_angle = Math.radians(rot_angle_deg);
-  mat4.fromRotation(M, rot_angle, rot_axis);
+  //var rot;
+  //mat4.fromRotation(rot, rot_angle, rot_axis);
+  //mat4.fromRotation(M, rot_angle, rot_axis);
+  
+  var rot = mat4.create();   
+  mat4.fromRotation(rot, rot_angle, rot_axis);
+  mat4.multiply(V,get_initial_V(),rot);
 };
 
 /////////////////////
@@ -151,13 +159,13 @@ function render(time){
 
   //Draw lobe
   gl.bindVertexArray(lobeVAO);
-  updateMVP(M, lobeProgram, lobe_mUniformLoc);
+  updateMVP(V, lobeProgram, lobe_vUniformLoc);
   var first = 0; //see https://stackoverflow.com/q/10221647
   gl.drawArrays(gl.TRIANGLES, first, num_lobe_verts);
 
   //Draw line
   gl.bindVertexArray(lineVAO);
-  updateMVP(M, lineProgram, line_mUniformLoc);
+  updateMVP(V, lineProgram, line_vUniformLoc);
   first = 0; 
   gl.drawArrays(gl.LINES, first, num_line_verts);
 

--- a/index.html
+++ b/index.html
@@ -14,10 +14,6 @@
     <script src="Scripts/hsvToRgb.js"></script>
     <script src="Scripts/gl-wrangling-funcs.js"></script>
     <script type="vertex" id="lobe.vert">#version 300 es
-
-        #define EPSILON 0.0001
-        #define M_PI 3.1415926535897932384626433832795
-        
         layout (location=0) in vec4 model_position;
         layout (location=1) in vec3 color;
         layout (location=2) in vec4 model_normal;
@@ -31,26 +27,11 @@
         //out vec4 world_position;
         out vec4 world_normal;
 
-        //float epsilon = 0.00001;
-
         void main() {
             //Assumes our input model coordinates are on the unit sphere.
           
-            /*
-            float theta = acos(model_position.z);
-            float phi; 
-
-            if(sin(theta) < EPSILON){
-              phi = 0.0;                
-            } else {
-              phi = acos(model_position.x / sin(theta)); 
-            }
-            */
-
-            //vec3 polar_color = vec3(theta/(M_PI/2.0),phi/(2.0*M_PI),0);
             vec3 polar_color = vec3(polar_coords.x/90.0,polar_coords.y/360.0,0);
-            //vec3 polar_color = vec3(polar_coords.x/90.0,0,0);
-            //vec3 polar_color = vec3(0,polar_coords.y/360.0,0);
+
             vColor = 0.99*polar_color + 0.01*color; //DEBUG ONLY
             gl_Position = u_p * u_v * u_m * model_position;
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
         uniform mat4 u_v;
         uniform mat4 u_p;
 
+        uniform vec3 u_n;
+        uniform vec3 u_l;
+
         uniform float u_delTheta;
         uniform float u_delPhi;
         
@@ -35,6 +38,32 @@
           float theta = (M_PI/180.0) * theta_deg; 
           float phi = (M_PI/180.0) * phi_deg;
           return vec3(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));
+        }
+
+        //L and N are assumed to be unit vectors
+        vec3 get_reflected(vec3 L, vec3 N){
+          vec3 L_plus_R = N * 2.0 * dot(L, N);
+          return normalize(L_plus_R - L);
+        }
+        
+        //TODO: Disney's tool doesn't incorporate the dot product / cosine weight because 
+        //that's not part of the BRDF, it's the "form factor" in the rendering equation.
+
+        //TODO: Disney's tool assumes BRDF returns a vec3? But I don't see where the color
+        //input is? 
+
+        //L, V, N assumed to be unit vectors
+        float BRDF(vec3 L, vec3 V, vec3 N){
+          //TODO: These should actually be uniforms.
+          const float k_d = 0.7;
+          const float k_s = 0.3;
+          const float spec_power = 20.0; 
+          
+          vec3 R = get_reflected(L, N);
+          float spec_val = pow(max(dot(R,V),0.0), spec_power);
+          float diffuse_val = max(0.0, dot(L,N)); 
+
+          return k_d*diffuse_val + k_s*spec_val;
         }
 
         void main() {
@@ -50,14 +79,41 @@
             //TODO: should we be working with radians "natively"?
             float theta_deg = polar_coords.x; 
             float phi_deg = polar_coords.y; 
-            vec3 p = polar_to_cartesian(theta_deg,phi_deg); //should be same as model_position
 
-            //gl_Position = u_p * u_v * u_m * model_position;
-            //gl_Position = u_p * u_v * u_m * vec4(p.x,p.y,p.z,1);
+            //prior to scaling, p SHOULD BE the same as position as model_position
+            vec3 p = polar_to_cartesian(theta_deg,phi_deg); 
+            vec3 p_U = polar_to_cartesian(theta_deg - u_delTheta,phi_deg); 
+            vec3 p_D = polar_to_cartesian(theta_deg + u_delTheta,phi_deg); 
+            vec3 p_L = polar_to_cartesian(theta_deg,phi_deg + u_delPhi); 
+            vec3 p_R = polar_to_cartesian(theta_deg,phi_deg - u_delPhi); 
+
+            //Scale points by the BRDF
+            float shade = BRDF(u_l, normalize(p), u_n);
+            p *= shade;
+            p_U *= shade;
+            p_D *= shade;
+            p_L *= shade;
+            p_R *= shade;
+
+            vec3 v1 = p_R - p;
+            vec3 v2 = p_U - p; 
+            vec3 v3 = p_L - p;
+            vec3 v4 = p_D - p;
+
+            vec3 n1 = normalize(cross(v2,v1));
+            vec3 n2 = normalize(cross(v3,v2));
+            vec3 n3 = normalize(cross(v4,v3));
+            vec3 n4 = normalize(cross(v1,v4));
+
+            vec3 avg_model_normal = normalize(n1 + n2 + n3 + n4);
+
+            //gl_Position = u_p * u_v * u_m * model_position; //old
             gl_Position = u_p * u_v * u_m * vec4(p,1);
 
             //world_normal = u_m * model_normal;
-            world_normal = model_normal; //DEBUG ONLY.
+            //world_normal = model_normal; //DEBUG ONLY.
+            //world_normal = vec4(avg_model_normal,1); 
+            world_normal = vec4(avg_model_normal,1); 
         }
     </script>
     <script type="fragment" id="phong.frag">#version 300 es
@@ -76,12 +132,15 @@
         out vec4 fragColor;
 
         void main() {
-            vec3 norm = normalize(world_normal.xyz);
+            //vec3 norm = normalize(world_normal.xyz);
             //vec3 to_light = normalize((u_world_light_pos.xyz - world_position.xyz)); 
             //fragColor = k_a*vColor + k_d*dot(norm, to_light)*vColor;
-            vec3 final_color = 0.01 * norm + 0.99 * vColor;
+            //vec3 final_color = 0.01 * norm + 0.99 * vColor;
             //vec3 final_color = 0.99 * norm + 0.01 * vColor;  
-            fragColor = vec4(final_color, 1.0); 
+            //vec3 final_color = vColor;
+
+            //fragColor = vec4(world_normal.xyz, 1.0); 
+            fragColor = vec4(vColor, 1);
         }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <script src="Scripts/hsvToRgb.js"></script>
     <script src="Scripts/gl-wrangling-funcs.js"></script>
     <script type="vertex" id="lobe.vert">#version 300 es
+        #define M_PI 3.1415926535897932384626433832795
+
         layout (location=0) in vec4 model_position;
         layout (location=1) in vec3 color;
         layout (location=2) in vec4 model_normal;
@@ -22,18 +24,37 @@
         uniform mat4 u_m;
         uniform mat4 u_v;
         uniform mat4 u_p;
+
+        uniform float u_delTheta;
+        uniform float u_delPhi;
         
         out vec3 vColor;
-        //out vec4 world_position;
         out vec4 world_normal;
 
-        void main() {
-            //Assumes our input model coordinates are on the unit sphere.
-          
-            vec3 polar_color = vec3(polar_coords.x/90.0,polar_coords.y/360.0,0);
+        vec3 polar_to_cartesian(float theta_deg, float phi_deg){
+          float theta = (M_PI/180.0) * theta_deg; 
+          float phi = (M_PI/180.0) * phi_deg;
+          return vec3(sin(theta)*cos(phi),sin(theta)*sin(phi),cos(theta));
+        }
 
+        void main() {
+            /*
+            //FOR DEBUG OF UNIT SPHERE
+            //Assumes our input model coordinates are on the unit sphere.
+            vec3 polar_color = vec3(polar_coords.x/90.0,polar_coords.y/360.0,0);
             vColor = 0.99*polar_color + 0.01*color; //DEBUG ONLY
-            gl_Position = u_p * u_v * u_m * model_position;
+            */
+
+            vColor = color;
+            
+            //TODO: should we be working with radians "natively"?
+            float theta_deg = polar_coords.x; 
+            float phi_deg = polar_coords.y; 
+            vec3 p = polar_to_cartesian(theta_deg,phi_deg); //should be same as model_position
+
+            //gl_Position = u_p * u_v * u_m * model_position;
+            //gl_Position = u_p * u_v * u_m * vec4(p.x,p.y,p.z,1);
+            gl_Position = u_p * u_v * u_m * vec4(p,1);
 
             //world_normal = u_m * model_normal;
             world_normal = model_normal; //DEBUG ONLY.

--- a/index.html
+++ b/index.html
@@ -13,11 +13,15 @@
     <script src='Scripts/webgl-obj-loader.js'></script>
     <script src="Scripts/hsvToRgb.js"></script>
     <script src="Scripts/gl-wrangling-funcs.js"></script>
-    <script type="vertex" id="phong.vert">#version 300 es
+    <script type="vertex" id="lobe.vert">#version 300 es
+
+        #define EPSILON 0.0001
+        #define M_PI 3.1415926535897932384626433832795
         
         layout (location=0) in vec4 model_position;
         layout (location=1) in vec3 color;
         layout (location=2) in vec4 model_normal;
+        layout (location=3) in vec2 polar_coords;
 
         uniform mat4 u_m;
         uniform mat4 u_v;
@@ -27,9 +31,29 @@
         //out vec4 world_position;
         out vec4 world_normal;
 
+        //float epsilon = 0.00001;
+
         void main() {
-            vColor = color;
+            //Assumes our input model coordinates are on the unit sphere.
+          
+            /*
+            float theta = acos(model_position.z);
+            float phi; 
+
+            if(sin(theta) < EPSILON){
+              phi = 0.0;                
+            } else {
+              phi = acos(model_position.x / sin(theta)); 
+            }
+            */
+
+            //vec3 polar_color = vec3(theta/(M_PI/2.0),phi/(2.0*M_PI),0);
+            vec3 polar_color = vec3(polar_coords.x/90.0,polar_coords.y/360.0,0);
+            //vec3 polar_color = vec3(polar_coords.x/90.0,0,0);
+            //vec3 polar_color = vec3(0,polar_coords.y/360.0,0);
+            vColor = 0.99*polar_color + 0.01*color; //DEBUG ONLY
             gl_Position = u_p * u_v * u_m * model_position;
+
             //world_normal = u_m * model_normal;
             world_normal = model_normal; //DEBUG ONLY.
         }
@@ -53,8 +77,8 @@
             vec3 norm = normalize(world_normal.xyz);
             //vec3 to_light = normalize((u_world_light_pos.xyz - world_position.xyz)); 
             //fragColor = k_a*vColor + k_d*dot(norm, to_light)*vColor;
-            //vec3 final_color = 0.01 * norm + 0.99 * vColor;
-            vec3 final_color = 0.99 * norm + 0.01 * vColor;  
+            vec3 final_color = 0.01 * norm + 0.99 * vColor;
+            //vec3 final_color = 0.99 * norm + 0.01 * vColor;  
             fragColor = vec4(final_color, 1.0); 
         }
     </script>

--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@
             //vec3 final_color = 0.99 * norm + 0.01 * vColor;  
             //vec3 final_color = vColor;
 
-            //fragColor = vec4(world_normal.xyz, 1.0); 
-            fragColor = vec4(vColor, 1);
+            fragColor = vec4(world_normal.xyz, 1.0); 
+            //fragColor = vec4(vColor, 1);
         }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -88,12 +88,12 @@
             vec3 p_R = polar_to_cartesian(theta_deg,phi_deg - u_delPhi); 
 
             //Scale points by the BRDF
-            float shade = BRDF(u_l, normalize(p), u_n);
-            p *= shade;
-            p_U *= shade;
-            p_D *= shade;
-            p_L *= shade;
-            p_R *= shade;
+            //float shade = BRDF(u_l, normalize(p), u_n);
+            p *= BRDF(u_l, normalize(p), u_n);
+            p_U *= BRDF(u_l, normalize(p_U), u_n);
+            p_D *= BRDF(u_l, normalize(p_D), u_n);
+            p_L *= BRDF(u_l, normalize(p_L), u_n);
+            p_R *= BRDF(u_l, normalize(p_R), u_n);
 
             vec3 v1 = p_R - p;
             vec3 v2 = p_U - p; 
@@ -112,8 +112,8 @@
 
             //world_normal = u_m * model_normal;
             //world_normal = model_normal; //DEBUG ONLY.
-            //world_normal = vec4(avg_model_normal,1); 
-            world_normal = vec4(avg_model_normal,1); 
+            //world_normal = vec4(avg_model_normal,1); //DEBUG ONLY
+            world_normal = u_m * vec4(avg_model_normal,1); 
         }
     </script>
     <script type="fragment" id="phong.frag">#version 300 es

--- a/known_issues.txt
+++ b/known_issues.txt
@@ -1,0 +1,1 @@
+1) We should probably change gl.DYNAMIC_DRAW calls to gl.STATIC_DRAW calls when we are done doing the lobe on GPU.

--- a/known_issues.txt
+++ b/known_issues.txt
@@ -1,1 +1,2 @@
 1) We should probably change gl.DYNAMIC_DRAW calls to gl.STATIC_DRAW calls when we are done doing the lobe on GPU.
+2) There is some sort of... seam when we set the color using polar_to_color. It's definitely not a mach band... does it appear near phi=0?


### PR DESCRIPTION
Now we deform the lobe geometry and compute normals on GPU instead of on the CPU. This step is needed in order to support Disney's `.brdf` files, which are really GLSL. (If we wanted to do everything on CPU, we would have to translate GLSL into JavaScript, which would be much harder to do.) 

We are now also computing smooth normals correctly. 

